### PR TITLE
RL7023 Stick-D/DSS対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@
 Python Route B Library: A Communicator for Low-voltage Smart Electric Energy Meters
 
 # Description
-MomongaはBルートサービスを利用してスマートメーターと通信するライブラリです。ターゲットデバイスはROHM社製Wi-SUNモジュールBP35C2を搭載したラトックシステムRS-WSUHA-Pです。
+MomongaはBルートサービスを利用してスマートメーターと通信するライブラリです。ターゲットデバイスはROHM社製Wi-SUNモジュールBP35C2または互換品です。
+
+# Tested Devices
+- ラトックシステム RS-WSUHA-P
+- テセラ・テクノロジー RL7023 Stick-D/DSS
 
 # Note
-Momongaは`WOPT 01\r`コマンドを実行して、Wi-SUNモジュールがUDPパケットのペイロードをASCIIフォーマットで出力するように設定します。注意: WOPTコマンドは実行回数に制限があるので初回のみ実行し、その設定はWi-SUNモジュールに保存されます。
+- Momongaは`WOPT 01\r`コマンドを実行して、Wi-SUNモジュールがUDPパケットのペイロードをASCIIフォーマットで出力するように設定します。注意: WOPTコマンドは実行回数に制限があるので初回のみ実行し、その設定はWi-SUNモジュールに保存されます。
+- 一部のWi-SUNモジュールでは`ROPT`コマンドが`FAIL ER04`を返しサポートされません。その場合MomongaはASCII出力で動作していると仮定し、`WOPT`コマンドを実行せずに処理を継続します。
 
 # Installation
 ```shell


### PR DESCRIPTION
RL7023 Stick-D/DSSへ対応します。

https://github.com/nbtk/momonga/issues/4#issuecomment-3379047196 での整理に基づき、次の対応しています。

- `exec_command` のエラー応答から例外を投げる処理を `__raise_fail_response` として切り出しました。
- `__exec_ropt` にエラー処理を追加し、`ROPT` 未実装で例外を投げるようにしました。
- `open` で `ROPT` 未実装の際、`WOPT` をスキップし、処理を継続するようにしました。
