### PR TITLE
Refine automatic session recovery API with reopen_delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ while True:
 - 送信がブロッキングされるなど諸条件により関数呼び出しのあと応答が即座に返らないことがあるため、`momonga.get_historical_cumulative_energy_1()`は呼び出したときに期待した履歴の日付と結果の日付に齟齬が生じる可能性があることに注意してください。特にこの関数は日を跨ぐタイミングで実行すべきではありません。
 
 # API
-## momonga.Momonga(rbid: str, pwd: str, dev: str, baudrate: int = 115200, reset_dev: bool = True)
+## momonga.Momonga(rbid: str, pwd: str, dev: str, baudrate: int = 115200, reset_dev: bool = True, reopen_delays: Iterable[float] | None = None)
 Momongaクラスのインスタンス化。
 ### Arguments
 - rbid: BルートID
@@ -147,6 +147,18 @@ Momongaクラスのインスタンス化。
 - dev: デバイスファイルへのパス
 - baudrate: シリアル通信のボーレート
 - reset_dev: momonga.open()を実行するときSKRESETコマンドを実行するかどうか
+- reopen_delays: `MomongaNeedToReopen` 発生時に再接続を試みるまでの待機秒数の列。`None` の場合は自動再接続しない。
+
+e.g.
+```python3
+from itertools import repeat
+
+# 3回まで10分おきに再接続する
+momonga.Momonga(rbid, pwd, dev, reopen_delays=[600.0, 600.0, 600.0])
+
+# 10分おきに無期限で再接続する
+momonga.Momonga(rbid, pwd, dev, reopen_delays=repeat(600.0))
+```
 
 ## momonga.open()
 PANをスキャンし、PANAセッションの確立を行う。　

--- a/momonga/momonga.py
+++ b/momonga/momonga.py
@@ -5,11 +5,14 @@ import queue
 import inspect
 import logging
 
+from collections.abc import Iterable
 from typing import TypedDict, Any, Self
 
-from .momonga_exception import (MomongaResponseNotExpected,
+from .momonga_exception import (MomongaError,
+                                MomongaResponseNotExpected,
                                 MomongaResponseNotPossible,
                                 MomongaNeedToReopen,
+                                MomongaValueError,
                                 MomongaRuntimeError)
 from .momonga_response import SkEventRxUdp
 from .momonga_session_manager import MomongaSessionManager
@@ -516,9 +519,7 @@ class Momonga:
                  dev: str,
                  baudrate: int = 115200,
                  reset_dev: bool = True,
-                 auto_reopen: bool = False,
-                 max_reopen_attempts: int = 3,
-                 reopen_backoff: int | float = 10,
+                 reopen_delays: Iterable[float] | None = None,
                  ) -> None:
         self.xmit_retries: int = 12
         self.recv_timeout: int | float = 12
@@ -527,9 +528,7 @@ class Momonga:
         self.energy_unit: int | float = 1
         self.energy_coefficient: int = 1
         self.is_open: bool = False
-        self.auto_reopen: bool = auto_reopen
-        self.max_reopen_attempts: int = max_reopen_attempts
-        self.reopen_backoff: int | float = reopen_backoff
+        self.reopen_delays: Iterable[float] | None = reopen_delays
         self._rbid: str = rbid
         self._pwd: str = pwd
         self._dev: str = dev
@@ -569,19 +568,19 @@ class Momonga:
         logger.info('Momonga is closed.')
 
     def reopen(self) -> None:
-        """Close and reopen the session to recover from connection failures."""
-        logger.info('Reopening Momonga session')
+        logger.info('Reopening Momonga session.')
         try:
             self.close()
         except MomongaError:
             logger.debug('Error closing Momonga during reopen (ignored)', exc_info=True)
         except OSError:
             logger.debug('OS error closing Momonga during reopen (ignored)', exc_info=True)
+
         self.session_manager = MomongaSessionManager(
             self._rbid, self._pwd, self._dev, self._baudrate, self._reset_dev
         )
         self.open()
-        logger.info('Momonga session reopened successfully')
+        logger.info('Momonga session reopened successfully.')
 
     def __get_transaction_id(self) -> int:
         self.transaction_id += 1
@@ -756,33 +755,33 @@ class Momonga:
                                 esv: EchonetServiceCode,
                                 req_properties: list[EchonetPropertyWithData] | list[EchonetProperty],
                                 ) -> list[EchonetPropertyWithData]:
-        """Request with automatic session recovery when auto_reopen is enabled."""
-        if not self.auto_reopen:
+        if self.reopen_delays is None:
             return self.__request(esv, req_properties)
 
         try:
             return self.__request(esv, req_properties)
         except MomongaNeedToReopen as initial_err:
             last_error: MomongaNeedToReopen = initial_err
-            logger.warning('Session needs reopen, attempting recovery (up to %d attempts)',
-                           self.max_reopen_attempts)
+            logger.warning('Session needs reopen, attempting recovery.')
 
-        for attempt in range(1, self.max_reopen_attempts + 1):
-            time.sleep(self.reopen_backoff)
+        for delay in self.reopen_delays:
+            delay = float(delay)
+            if delay < 0:
+                raise MomongaValueError('reopen_delays must not contain negative values.')
+
+            time.sleep(delay)
             try:
                 self.reopen()
                 return self.__request(esv, req_properties)
             except MomongaNeedToReopen as err:
                 last_error = err
-                logger.warning('Reopen attempt %d/%d failed: %s',
-                               attempt, self.max_reopen_attempts, err)
+                logger.warning('Reopen attempt failed after waiting %s seconds: %s', delay, err)
             except (MomongaError, OSError) as err:
-                logger.warning('Reopen attempt %d/%d failed: %s: %s',
-                               attempt, self.max_reopen_attempts,
-                               type(err).__name__, err)
+                logger.warning('Reopen attempt failed after waiting %s seconds: %s: %s',
+                               delay, type(err).__name__, err)
                 last_error = MomongaNeedToReopen(str(err))
 
-        logger.error('All %d reopen attempts exhausted', self.max_reopen_attempts)
+        logger.error('All reopen attempts exhausted.')
         raise last_error
 
     def __request_to_set(self,

--- a/momonga/momonga.py
+++ b/momonga/momonga.py
@@ -571,10 +571,8 @@ class Momonga:
         logger.info('Reopening Momonga session.')
         try:
             self.close()
-        except MomongaError:
+        except Exception:
             logger.debug('Error closing Momonga during reopen (ignored)', exc_info=True)
-        except OSError:
-            logger.debug('OS error closing Momonga during reopen (ignored)', exc_info=True)
 
         self.session_manager = MomongaSessionManager(
             self._rbid, self._pwd, self._dev, self._baudrate, self._reset_dev

--- a/momonga/momonga.py
+++ b/momonga/momonga.py
@@ -516,6 +516,9 @@ class Momonga:
                  dev: str,
                  baudrate: int = 115200,
                  reset_dev: bool = True,
+                 auto_reopen: bool = False,
+                 max_reopen_attempts: int = 3,
+                 reopen_backoff: int | float = 10,
                  ) -> None:
         self.xmit_retries: int = 12
         self.recv_timeout: int | float = 12
@@ -524,6 +527,14 @@ class Momonga:
         self.energy_unit: int | float = 1
         self.energy_coefficient: int = 1
         self.is_open: bool = False
+        self.auto_reopen: bool = auto_reopen
+        self.max_reopen_attempts: int = max_reopen_attempts
+        self.reopen_backoff: int | float = reopen_backoff
+        self._rbid: str = rbid
+        self._pwd: str = pwd
+        self._dev: str = dev
+        self._baudrate: int = baudrate
+        self._reset_dev: bool = reset_dev
         self.session_manager = MomongaSessionManager(rbid, pwd, dev, baudrate, reset_dev)
 
     def __init_energy_unit(self) -> None:
@@ -556,6 +567,21 @@ class Momonga:
         self.is_open = False
         self.session_manager.close()
         logger.info('Momonga is closed.')
+
+    def reopen(self) -> None:
+        """Close and reopen the session to recover from connection failures."""
+        logger.info('Reopening Momonga session')
+        try:
+            self.close()
+        except MomongaError:
+            logger.debug('Error closing Momonga during reopen (ignored)', exc_info=True)
+        except OSError:
+            logger.debug('OS error closing Momonga during reopen (ignored)', exc_info=True)
+        self.session_manager = MomongaSessionManager(
+            self._rbid, self._pwd, self._dev, self._baudrate, self._reset_dev
+        )
+        self.open()
+        logger.info('Momonga session reopened successfully')
 
     def __get_transaction_id(self) -> int:
         self.transaction_id += 1
@@ -726,15 +752,48 @@ class Momonga:
         raise MomongaNeedToReopen('Gave up to obtain a response for transaction id "%04X".'
                                   ' Close Momonga and open it again.' % tid)
 
+    def __request_with_recovery(self,
+                                esv: EchonetServiceCode,
+                                req_properties: list[EchonetPropertyWithData] | list[EchonetProperty],
+                                ) -> list[EchonetPropertyWithData]:
+        """Request with automatic session recovery when auto_reopen is enabled."""
+        if not self.auto_reopen:
+            return self.__request(esv, req_properties)
+
+        try:
+            return self.__request(esv, req_properties)
+        except MomongaNeedToReopen as initial_err:
+            last_error: MomongaNeedToReopen = initial_err
+            logger.warning('Session needs reopen, attempting recovery (up to %d attempts)',
+                           self.max_reopen_attempts)
+
+        for attempt in range(1, self.max_reopen_attempts + 1):
+            time.sleep(self.reopen_backoff)
+            try:
+                self.reopen()
+                return self.__request(esv, req_properties)
+            except MomongaNeedToReopen as err:
+                last_error = err
+                logger.warning('Reopen attempt %d/%d failed: %s',
+                               attempt, self.max_reopen_attempts, err)
+            except (MomongaError, OSError) as err:
+                logger.warning('Reopen attempt %d/%d failed: %s: %s',
+                               attempt, self.max_reopen_attempts,
+                               type(err).__name__, err)
+                last_error = MomongaNeedToReopen(str(err))
+
+        logger.error('All %d reopen attempts exhausted', self.max_reopen_attempts)
+        raise last_error
+
     def __request_to_set(self,
                          properties_with_data: list[EchonetPropertyWithData]
                          ) -> None:
-        self.__request(EchonetServiceCode.set_c, properties_with_data)
+        self.__request_with_recovery(EchonetServiceCode.set_c, properties_with_data)
 
     def __request_to_get(self,
                          properties: list[EchonetProperty],
                          ) -> list[EchonetPropertyWithData]:
-        return self.__request(EchonetServiceCode.get, properties)
+        return self.__request_with_recovery(EchonetServiceCode.get, properties)
 
     def get_operation_status(self) -> bool | None:
         req = EchonetProperty(EchonetPropertyCode.operation_status)

--- a/momonga/momonga_exception.py
+++ b/momonga/momonga_exception.py
@@ -42,6 +42,10 @@ class MomongaRuntimeError(RuntimeError):
     pass
 
 
+class MomongaValueError(ValueError):
+    pass
+
+
 class MomongaTimeoutError(TimeoutError):
     pass
 

--- a/momonga/momonga_session_manager.py
+++ b/momonga/momonga_session_manager.py
@@ -153,8 +153,10 @@ class MomongaSessionManager:
 
         self.unrestrict_to_xmit(force=True)
 
-        assert self.xmit_lock.locked() is False, '"xmit_lock" is unexpectedly locked.'
-        assert self.rejoin_lock.locked() is False, '"rejoin_lock" is unexpectedly locked.'
+        if self.xmit_lock.locked():
+            logger.error('"xmit_lock" is unexpectedly locked.')
+        if self.rejoin_lock.locked():
+            logger.error('"rejoin_lock" is unexpectedly locked.')
 
         self.skw.close()
         logger.info('The Momonga session is closed.')

--- a/tests/error_handling_example.py
+++ b/tests/error_handling_example.py
@@ -8,6 +8,7 @@ rbid = os.environ.get('MOMONGA_ROUTEB_ID')
 pwd = os.environ.get('MOMONGA_ROUTEB_PASSWORD')
 dev = os.environ.get('MOMONGA_DEV_PATH')
 
+# Example 1: Manual recovery (original pattern)
 while True:
     try:
         with momonga.Momonga(rbid, pwd, dev) as mo:
@@ -18,5 +19,23 @@ while True:
     except (momonga.MomongaSkScanFailure,
             momonga.MomongaSkJoinFailure,
             momonga.MomongaNeedToReopen) as e:
+        print('%s: %s' % (type(e).__name__, e), file=sys.stderr)
+        continue
+
+# Example 2: Automatic recovery using auto_reopen
+# When auto_reopen is enabled, Momonga will automatically attempt to
+# reopen the session when MomongaNeedToReopen is raised during requests.
+while True:
+    try:
+        with momonga.Momonga(rbid, pwd, dev, auto_reopen=True) as mo:
+            while True:
+                res = mo.get_instantaneous_power()
+                print('%0.1fW' % res)
+                time.sleep(60)
+    except (momonga.MomongaSkScanFailure,
+            momonga.MomongaSkJoinFailure,
+            momonga.MomongaNeedToReopen) as e:
+        # MomongaNeedToReopen is raised only after all automatic
+        # reopen attempts are exhausted.
         print('%s: %s' % (type(e).__name__, e), file=sys.stderr)
         continue

--- a/tests/show_supported_epcs.py
+++ b/tests/show_supported_epcs.py
@@ -1,0 +1,43 @@
+import momonga
+import os
+import sys
+
+def main():
+    rbid = os.environ.get('MOMONGA_ROUTEB_ID')
+    pwd = os.environ.get('MOMONGA_ROUTEB_PASSWORD')
+    dev = os.environ.get('MOMONGA_DEV_PATH')
+
+    if not rbid or not pwd or not dev:
+        print("Please set MOMONGA_ROUTEB_ID, MOMONGA_ROUTEB_PASSWORD, and MOMONGA_DEV_PATH environment variables.", file=sys.stderr)
+        sys.exit(1)
+
+    print("Connecting to the smart meter... This may take a minute.")
+    
+    try:
+        with momonga.Momonga(rbid, pwd, dev) as mo:
+            print("\nConnection established.\n")
+            
+            def print_props(props, label):
+                print(f"--- Supported Properties ({label}) ---")
+                if props:
+                    for prop in sorted(props, key=lambda x: x.value if hasattr(x, 'value') else x):
+                        if type(prop) is int:
+                            print(f"0x{prop:02X} : (Unknown/Unsupported by Momonga)")
+                        else:
+                            print(f"0x{prop.value:02X} : {prop.name}")
+                else:
+                    print("None found or not supported.")
+                print()
+
+            print_props(mo.get_properties_to_get_values(), "GET")
+            print_props(mo.get_properties_to_set_values(), "SET")
+            print_props(mo.get_properties_for_status_notification(), "Status Change Notification")
+            
+    except (momonga.MomongaSkScanFailure,
+            momonga.MomongaSkJoinFailure,
+            momonga.MomongaNeedToReopen) as e:
+        print(f"Connection Failed - {type(e).__name__}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_reopen_delays.py
+++ b/tests/test_reopen_delays.py
@@ -1,0 +1,59 @@
+import unittest
+from unittest.mock import patch
+
+import momonga
+
+
+class TestReopenDelays(unittest.TestCase):
+    def setUp(self) -> None:
+        self.instance = momonga.Momonga('rbid', 'pwd', '/dev/null', reopen_delays=[256.0, 1024.0])
+
+    def test_request_retries_after_reopen(self) -> None:
+        request_calls = []
+
+        def fake_request(_esv, _props):
+            request_calls.append(1)
+            if len(request_calls) == 1:
+                raise momonga.MomongaNeedToReopen('retry me')
+            return ['ok']
+
+        with patch.object(self.instance, '_Momonga__request', side_effect=fake_request), \
+                patch.object(self.instance, 'reopen') as reopen_mock, \
+                patch('momonga.momonga.time.sleep') as sleep_mock:
+            result = self.instance._Momonga__request_with_recovery(
+                momonga.momonga.EchonetServiceCode.get,
+                [],
+            )
+
+        self.assertEqual(result, ['ok'])
+        self.assertEqual(len(request_calls), 2)
+        reopen_mock.assert_called_once_with()
+        sleep_mock.assert_called_once_with(256.0)
+
+    def test_request_raises_after_delays_exhausted(self) -> None:
+        with patch.object(self.instance, '_Momonga__request', side_effect=momonga.MomongaNeedToReopen('still failing')), \
+                patch.object(self.instance, 'reopen') as reopen_mock, \
+                patch('momonga.momonga.time.sleep') as sleep_mock:
+            with self.assertRaises(momonga.MomongaNeedToReopen):
+                self.instance._Momonga__request_with_recovery(
+                    momonga.momonga.EchonetServiceCode.get,
+                    [],
+                )
+
+        self.assertEqual(reopen_mock.call_count, 2)
+        self.assertEqual(sleep_mock.call_args_list[0].args, (256.0,))
+        self.assertEqual(sleep_mock.call_args_list[1].args, (1024.0,))
+
+    def test_negative_delay_is_rejected(self) -> None:
+        instance = momonga.Momonga('rbid', 'pwd', '/dev/null', reopen_delays=[-1.0])
+
+        with patch.object(instance, '_Momonga__request', side_effect=momonga.MomongaNeedToReopen('retry me')):
+            with self.assertRaises(momonga.MomongaValueError):
+                instance._Momonga__request_with_recovery(
+                    momonga.momonga.EchonetServiceCode.get,
+                    [],
+                )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR builds on the work proposed in #12.

Changes:
- keep automatic session recovery in the library
- replace retry-count / backoff parameters with `reopen_delays`
- add unit tests for recovery behavior and invalid delay values

The original implementation from #12 was cherry-picked and refined here so the contribution remains in the project history.